### PR TITLE
Sort after loading pre-trained word vectors

### DIFF
--- a/pyner/util/vocab.py
+++ b/pyner/util/vocab.py
@@ -75,8 +75,10 @@ class Vocabulary:
         if self.gensim_model_path:
             self._load_pretrained_word_vectors(self.gensim_model_path)
 
-        for name, vocab_arr in self.vocab_arr.items():
-            vocabulary = {w: i for i, w in enumerate(sorted(vocab_arr))}
+        for name in self.vocab_arr.keys():
+            # NOTE python dictionaries are unordered
+            self.vocab_arr[name] = sorted(self.vocab_arr[name])
+            vocabulary = {w: i for i, w in enumerate(sorted(self.vocab_arr[name]))}  # NOQA
             if name in FIELDS_NEED_SPECIAL_SYMBOLS:
                 vocabulary = _insert_special_symbols(vocabulary)
             self.dictionaries[f'{name}2idx'] = vocabulary

--- a/pyner/util/vocab.py
+++ b/pyner/util/vocab.py
@@ -69,14 +69,14 @@ class Vocabulary:
         for field, vocab in self.vocab_arr.items():
             if field in FIELDS_PREPROCESSED:
                 vocab = self._process(vocab)
-            vocab_arr = sorted(list(set(vocab)))
+            vocab_arr = list(set(vocab))
             self.vocab_arr[field] = vocab_arr
 
         if self.gensim_model_path:
             self._load_pretrained_word_vectors(self.gensim_model_path)
 
         for name, vocab_arr in self.vocab_arr.items():
-            vocabulary = {w: i for i, w in enumerate(vocab_arr)}
+            vocabulary = {w: i for i, w in enumerate(sorted(vocab_arr))}
             if name in FIELDS_NEED_SPECIAL_SYMBOLS:
                 vocabulary = _insert_special_symbols(vocabulary)
             self.dictionaries[f'{name}2idx'] = vocabulary
@@ -133,15 +133,15 @@ class Vocabulary:
         else:
             return Exception('Unknown operator is specified')
 
-        msg = f'num_vocab: \x1b[31m{len(vc)}\x1b[0m'
+        num_vocab = len(vc)
+        msg = f' num_vocab: \x1b[31m{num_vocab}\x1b[0m'
         msg += f' (with set operator \x1b[31m{operator}\x1b[0m)'
         logger.debug(msg)
         return vc
 
     def _load_pretrained_word_vectors(self, word_vector_path):
         from gensim.models import KeyedVectors
-        msg = 'Load pre-trained word vectors:'
-        msg += f' \x1b[31m{word_vector_path}\x1b[0m'
+        msg = f'Load word vectors from \x1b[31m{word_vector_path}\x1b[0m'
         logger.debug(msg)
         self.gensim_model = KeyedVectors.load(word_vector_path)
         vocab_arr = list(self.gensim_model.vocab.keys())


### PR DESCRIPTION
In `Python<3.7`, dictionaries are unordered.
If we want to use the same dictionary, it has to sort elements before creating it.
In [this line](https://github.com/himkt/pyner/compare/himkt/sort-vocab-arr?expand=1#diff-9d2f71d4ea5e17801f6ec8aa60b24723L76), `vocab_arr` is updated, which is after sorting ([link](https://github.com/himkt/pyner/compare/himkt/sort-vocab-arr?expand=1#diff-9d2f71d4ea5e17801f6ec8aa60b24723L72))