### PR TITLE
Update dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
+# Dockerfile for himkt/pyner
+
+
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
+
 ENV PYTHONIOENCODING "utf-8"
 ARG GID
 ARG UID

--- a/pyner/named_entity/train.py
+++ b/pyner/named_entity/train.py
@@ -62,6 +62,8 @@ if __name__ == '__main__':
 
     if args.device >= 0:
         chainer.cuda.get_device(args.device).use()
+        chainer.config.use_cudnn = 'never'
+
     set_seed(args.seed, args.device)
 
     configs = ConfigParser.parse(args.config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 gensim==3.6.0
 numpy==1.15.4
-scikit-learn==0.19
+scikit-learn==0.21.2
 seqeval==0.0.5
 pyyaml==4.2b1
 
-# git+https://github.com/himkt/chainer.git@add-permutate-in-crf1d
-git+https://github.com/himkt/chainer.git@crf-with-adabound
+chainer==7.0.0a1
 chainerui==0.9.0

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,1 +1,1 @@
-cupy-cuda92==6.0.0b1
+cupy-cuda101==7.0.0a1


### PR DESCRIPTION
Because the features of AdaBound and automatically sorting in CRF are now available in
the latest release of Chainer, it is the time to stop using the fork repo.