### PR TITLE
Avoid cudnn bad params

### DIFF
--- a/pyner/named_entity/recognizer.py
+++ b/pyner/named_entity/recognizer.py
@@ -5,8 +5,10 @@ import chainer.functions as F
 import chainer.links as L
 import chainer
 import logging
+import os
 
 
+ENABLE_NSTEP_LSTM_TRICK = os.getenv('ENABLE_FASTER_IMPLEMENTATION') == '1'
 logger = logging.getLogger(__name__)
 
 
@@ -22,6 +24,8 @@ class BiLSTM_CRF(chainer.Chain):
                  num_tag_vocab
                  ):
 
+        if ENABLE_NSTEP_LSTM_TRICK:
+            logger.info('USE FASTER IMPLEMENTATION')
         super(BiLSTM_CRF, self).__init__()
         if 'model' not in configs:
             raise Exception('Model configurations are not found')
@@ -185,7 +189,7 @@ class BiLSTM_CRF(chainer.Chain):
         _, batch_size, _ = hy.shape
 
         # NOTE https://github.com/himkt/pyner/pull/39
-        if batch_size == 1 and len(char_inputs[0]) == 1:
+        if ENABLE_NSTEP_LSTM_TRICK and batch_size == 1 and len(char_inputs[0]) == 1:
             hs = hs[0]
         else:
             hs = hy.transpose([1, 0, 2])

--- a/pyner/named_entity/recognizer.py
+++ b/pyner/named_entity/recognizer.py
@@ -181,15 +181,15 @@ class BiLSTM_CRF(chainer.Chain):
         shape = [2, batch_size, self.char_hidden_dim]
 
         h_0, c_0 = self.create_init_state(shape)
-        hs, _, hy = self.char_level_bilstm(h_0, c_0, char_embs)
-        _, batch_size, _ = hs.shape
+        hy, _, hs = self.char_level_bilstm(h_0, c_0, char_embs)
+        _, batch_size, _ = hy.shape
 
         # NOTE https://github.com/himkt/pyner/pull/39
         if batch_size == 1 and len(char_inputs[0]) == 1:
-            hs = hy[0]
+            hs = hs[0]
         else:
-            hs = hs.transpose([1, 0, 2])
-            hs = hs.reshape(batch_size, -1)
+            hs = hy.transpose([1, 0, 2])
+            hs = hy.reshape(batch_size, -1)
         char_features.append(hs)
 
         # final timestep for each sequence

--- a/pyner/named_entity/recognizer.py
+++ b/pyner/named_entity/recognizer.py
@@ -181,10 +181,15 @@ class BiLSTM_CRF(chainer.Chain):
         shape = [2, batch_size, self.char_hidden_dim]
 
         h_0, c_0 = self.create_init_state(shape)
-        hs, _, _ = self.char_level_bilstm(h_0, c_0, char_embs)
+        hs, _, hy = self.char_level_bilstm(h_0, c_0, char_embs)
         _, batch_size, _ = hs.shape
-        hs = hs.transpose([1, 0, 2])
-        hs = hs.reshape(batch_size, -1)
+
+        # NOTE https://github.com/himkt/pyner/pull/39
+        if batch_size == 1 and len(char_inputs[0]) == 1:
+            hs = hy[0]
+        else:
+            hs = hs.transpose([1, 0, 2])
+            hs = hs.reshape(batch_size, -1)
         char_features.append(hs)
 
         # final timestep for each sequence

--- a/pyner/named_entity/train.py
+++ b/pyner/named_entity/train.py
@@ -160,8 +160,7 @@ if __name__ == '__main__':
     trainer.extend(E.LogReport(trigger=epoch_trigger))
     trainer.extend(E.PrintReport(entries=entries), trigger=epoch_trigger)
     trainer.extend(E.ProgressBar(update_interval=20))
-    trainer.extend(E.snapshot_object(model, filename=snapshot_filename),
-                   trigger=(1, 'epoch'))
+    # trainer.extend(E.snapshot_object(model, filename=snapshot_filename), trigger=(1, 'epoch'))  # NOQA
 
     if 'learning_rate_decay' in params:
         logger.debug('Enable Learning Rate decay')

--- a/pyner/named_entity/train.py
+++ b/pyner/named_entity/train.py
@@ -62,7 +62,6 @@ if __name__ == '__main__':
 
     if args.device >= 0:
         chainer.cuda.get_device(args.device).use()
-        chainer.config.use_cudnn = 'never'
 
     set_seed(args.seed, args.device)
 


### PR DESCRIPTION
Solve https://github.com/himkt/pyner/issues/38.

Avoid `CUDNN_STATUS_BAD_PARAMS` when processing a sentence that consists of only one character.
After merging this PR, I will fix `create_initial_state` and inspect the performance issue of faster implementation #39

I'm now conducting an experiment on CoNLL2003.
If there is no problem in performance, I will merge it soon.

I sincerely appreciate @chantera's PR.