### PR TITLE
Add sample config for simple LSTM-CRF

### DIFF
--- a/config/model/simple-lstm-crf.yaml
+++ b/config/model/simple-lstm-crf.yaml
@@ -1,0 +1,3 @@
+word_dim: 100
+word_hidden_dim: 100
+dropout: 0.5

--- a/config/training/simple-lstm-crf.yaml
+++ b/config/training/simple-lstm-crf.yaml
@@ -1,0 +1,6 @@
+iteration: "./config/iteration/long.yaml"
+external: "./config/external/conll2003.yaml"
+model: "./config/model/simple-lstm-crf.yaml"
+optimizer: "./config/optimizer/sgd_with_clipping.yaml"
+preprocessing: "./config/preprocessing/znorm.yaml"
+output: "./model/baseline"


### PR DESCRIPTION
This PR add the config of LSTM-CRF without char-encoder.