### PR TITLE
Replace whitespace with special symbol

### DIFF
--- a/pyner/named_entity/inference.py
+++ b/pyner/named_entity/inference.py
@@ -67,6 +67,7 @@ def run_inference(model: str, epoch: Optional[int], device: str, metric: str):
             sentence_gen = zip(word_sentences, t_tag_sentences, p_tag_sentences)  # NOQA
             for ws, ts, ps in sentence_gen:
                 for w, t, p in zip(ws, ts, ps):
+                    w = w.replace(" ", "<WHITESPACE>")
                     print(f"{w} {t} {p}", file=file)
                 print(file=file)
 


### PR DESCRIPTION
I executed `conlleval` and got the error `unexpected number of features: 4 (3)`.
This problem caused when the word is a whitespace `" "`, so I replace them with special characters.
