### PR TITLE
Add flag 'return_original_sentence'

### DIFF
--- a/pyner/named_entity/dataset.py
+++ b/pyner/named_entity/dataset.py
@@ -91,13 +91,15 @@ class DatasetTransformer:
 
 
 class SequenceLabelingDataset(D.DatasetMixin):
-    def __init__(self, vocab, params, mode, transform):
+    def __init__(self, vocab, params, mode, transform,
+                 return_original_sentence=False):
         data_path = os.path.join(params["data_dir"], f"{mode}.txt")
         datas = vocab.load_word_sentences(data_path)
         word_sentences, tag_sentences = update_instances(datas, params, mode)
         self.word_sentences = word_sentences
         self.tag_sentences = tag_sentences
 
+        self.return_original_sentence = return_original_sentence
         self.num_sentences = len(word_sentences)
         self.transform = transform
 
@@ -107,4 +109,9 @@ class SequenceLabelingDataset(D.DatasetMixin):
     def get_example(self, i):
         word_line = self.word_sentences[i]
         tag_line = self.tag_sentences[i]
-        return self.transform(word_line, tag_line)
+
+        ret = self.transform(word_line, tag_line)
+        if self.return_original_sentence:
+            return ret, word_line
+        else:
+            return ret

--- a/pyner/util/iterator.py
+++ b/pyner/util/iterator.py
@@ -2,7 +2,10 @@ import chainer.iterators as It
 from pyner.named_entity.dataset import SequenceLabelingDataset
 
 
-def create_iterator(vocab, configs, mode, transform):
+def create_iterator(
+        vocab, configs, mode, transform,
+        return_original_sentence=False
+):
     if "iteration" not in configs:
         raise Exception("Batch configurations are not found")
 
@@ -13,7 +16,13 @@ def create_iterator(vocab, configs, mode, transform):
     iteration_configs = configs["iteration"]
     external_configs = configs["external"]
 
-    dataset = SequenceLabelingDataset(vocab, external_configs, mode, transform)
+    dataset = SequenceLabelingDataset(
+        vocab,
+        external_configs,
+        mode,
+        transform,
+        return_original_sentence=return_original_sentence
+    )
     batch_size = iteration_configs["batch_size"] if is_train else len(dataset)
 
     iterator = It.SerialIterator(


### PR DESCRIPTION
Because `pyner` convert a sentence into an array of word/character indices in an iterator,
there was no way to get original words that were replaced with a special symbol `UNK`.

This PR introduces `return_original_sentence` option to make an iterator include original sentences.